### PR TITLE
fixed disk partition unit

### DIFF
--- a/kvm/rhel/6/functions/disk.sh
+++ b/kvm/rhel/6/functions/disk.sh
@@ -314,7 +314,9 @@ function mkpart() {
   }
 
   printf "[INFO] Adding type %s partition to disk image: %s\n" ${fstype} ${disk_filename}
-  parted --script -- ${disk_filename} mkpart ${parttype} ${fstype} ${partition_start} ${partition_end}
+  # parted default unit is not "mib" but "mb"
+  local unit=mib
+  parted --script -- ${disk_filename} mkpart ${parttype} ${fstype} ${partition_start}${unit} ${partition_end}${unit}
   # for physical /dev/XXX
   udevadm settle
 }


### PR DESCRIPTION
MB -> MiB

```
hansode:~/work/repos/git/github.com/vmbuilder/kvm/rhel/6(master)$ sudo kpartx -va ./centos-6.3_x86_64.fixed.raw
add map loop0p1 (253:0): 0 8386498 linear /dev/loop0 63
add map loop0p2 (253:1): 0 2095104 linear /dev/loop0 8388608

hansode:~/work/repos/git/github.com/vmbuilder/kvm/rhel/6(master)$ sudo kpartx -va ./centos-6.3_x86_64.unfixed.raw
add map loop1p1 (253:2): 0 7997984 linear /dev/loop1 63
add map loop1p2 (253:3): 0 1998848 linear /dev/loop1 7999488

hansode:~/work/repos/git/github.com/vmbuilder/kvm/rhel/6(master)$ sudo mount -o ro /dev/mapper/loop0p1 ./mnt-fixed
hansode:~/work/repos/git/github.com/vmbuilder/kvm/rhel/6(master)$ sudo mount -o ro /dev/mapper/loop1p1 ./mnt-unfixed

hansode:~/work/repos/git/github.com/vmbuilder/kvm/rhel/6(master)$ df -h
Filesystem            Size  Used Avail Use% Mounted on
/dev/sda2             274G   72G  188G  28% /
tmpfs                 5.9G     0  5.9G   0% /dev/shm
/dev/mapper/loop0p1   4.0G  637M  3.2G  17% /home/hansode/work/repos/git/github.com/vmbuilder/kvm/rhel/6/mnt-fixed
/dev/mapper/loop1p1   3.8G  637M  3.0G  18% /home/hansode/work/repos/git/github.com/vmbuilder/kvm/rhel/6/mnt-unfixed
```
