### PR TITLE
sshd_permit_root_login parameter

### DIFF
--- a/kvm/rhel/6/functions/distro.sh
+++ b/kvm/rhel/6/functions/distro.sh
@@ -80,6 +80,7 @@ function add_option_distro() {
   ssh_key=${ssh_key:-}
   ssh_user_key=${ssh_user_key:-}
   sshd_passauth=${sshd_passauth:-}
+  sshd_permit_root_login=${sshd_permit_root_login:-}
 
   fstab_type=${fstab_type:-uuid}
 
@@ -462,6 +463,20 @@ function configure_sshd_password_authentication() {
     echo "PasswordAuthentication ${passauth}" >> ${chroot_dir}/etc/ssh/sshd_config
   }
   sed -i "s/^\(PasswordAuthentication\).*/\1 ${passauth}/" ${chroot_dir}/etc/ssh/sshd_config
+}
+
+function configure_sshd_permit_root_login() {
+  local chroot_dir=$1 permit_root_login=${2:-${sshd_permit_root_login}}
+  [[ -a "${chroot_dir}/etc/ssh/sshd_config" ]] || { echo "[WARN] file not found: ${chroot_dir}/etc/ssh/sshd_config (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 0; }
+
+  case "${permit_root_login}" in
+  yes|no|without-password|forced-commands-only) ;;
+  *) permit_root_login=yes ;;
+  esac
+
+  printf "[INFO] Configuring sshd PermitRootLogin: %s\n" ${permit_root_login}
+  sed -i "s/^#\(PermitRootLogin\).*/\1 ${permit_root_login}/" ${chroot_dir}/etc/ssh/sshd_config
+  sed -i "s/^\(PermitRootLogin\).*/\1 ${permit_root_login}/"  ${chroot_dir}/etc/ssh/sshd_config
 }
 
 function check_sudo_requiretty() {

--- a/kvm/rhel/6/functions/hypervisor.sh
+++ b/kvm/rhel/6/functions/hypervisor.sh
@@ -19,7 +19,7 @@
 #  distro: add_option_distro, preflight_check_distro, install_kernel, install_bootloader, install_epel, install_addedpkgs, mount_proc
 #          create_initial_user, install_authorized_keys
 #          mount_dev, mount_sys, configure_networking, configure_mounting, configure_keepcache, configure_console
-#          configure_hypervisor, configure_selinux, configure_sshd_password_authentication, configure_sudo_requiretty
+#          configure_hypervisor, configure_selinux, configure_sshd_password_authentication, configure_sshd_permit_root_login, configure_sudo_requiretty
 #          run_xcopy, xsync_dir, run_xexecscript, install_firstboot, install_firstlogin, convert_rpmdb_hash, clean_packages
 #
 
@@ -193,6 +193,7 @@ function install_os() {
     install_bootloader ${chroot_dir} ${disk_filename}
   }
   configure_sshd_password_authentication ${chroot_dir} ${sshd_passauth}
+  configure_sshd_permit_root_login       ${chroot_dir} ${sshd_permit_root_login}
   configure_sudo_requiretty              ${chroot_dir} ${sudo_requiretty}
 
   install_epel         ${chroot_dir}

--- a/kvm/rhel/6/test/unit/04_distro/t.configure_sshd_permit_root_login.sh
+++ b/kvm/rhel/6/test/unit/04_distro/t.configure_sshd_permit_root_login.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# requires:
+#   bash
+#
+
+## include files
+
+. $(cd ${BASH_SOURCE[0]%/*} && pwd)/helper_shunit2.sh
+
+## variables
+
+## public functions
+
+function setUp() {
+  mkdir -p ${chroot_dir}/etc/ssh
+  cat <<-EOS > ${chroot_dir}/etc/ssh/sshd_config
+	#PermitRootLogin yes
+EOS
+  sshd_permit_root_login=
+}
+
+function tearDown() {
+  rm -rf ${chroot_dir}
+}
+
+function test_configure_sshd_permit_root_login_file_not_found() {
+  rm ${chroot_dir}/etc/ssh/sshd_config
+
+  configure_sshd_permit_root_login ${chroot_dir} 2>/dev/null
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_empty() {
+  configure_sshd_permit_root_login ${chroot_dir} >/dev/null
+
+  egrep -q -w "^PermitRootLogin yes" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_yes() {
+  local permit_root_login=yes
+  configure_sshd_permit_root_login ${chroot_dir} ${permit_root_login} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_no() {
+  local permit_root_login=no
+  configure_sshd_permit_root_login ${chroot_dir} ${permit_root_login} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_without_password() {
+  local permit_root_login=without-password
+  configure_sshd_permit_root_login ${chroot_dir} ${permit_root_login} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_forced_commands_only() {
+  local permit_root_login=forced-commands-only
+  configure_sshd_permit_root_login ${chroot_dir} ${permit_root_login} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_with_sshd_permit_root_login_yes() {
+  local sshd_permit_root_login=yes
+  configure_sshd_permit_root_login ${chroot_dir} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${sshd_permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_with_sshd_permit_root_login_no() {
+  local sshd_permit_root_login=no
+  configure_sshd_permit_root_login ${chroot_dir} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${sshd_permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_with_sshd_permit_root_login_without_password() {
+  local sshd_permit_root_login=without-password
+  configure_sshd_permit_root_login ${chroot_dir} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${sshd_permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+function test_configure_sshd_permit_root_login_with_sshd_permit_root_login_forced_commands_only() {
+  local sshd_permit_root_login=forced-commands-only
+  configure_sshd_permit_root_login ${chroot_dir} >/dev/null
+
+  egrep -q -w "^PermitRootLogin ${sshd_permit_root_login}" ${chroot_dir}/etc/ssh/sshd_config
+  assertEquals $? 0
+}
+
+## shunit2
+
+. ${shunit2_file}

--- a/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.diskless.sh
+++ b/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.diskless.sh
@@ -32,6 +32,7 @@ function setUp() {
   function configure_hypervisor() { echo configure_hypervisor $*; }
   function configure_selinux() { echo configure_selinux $*; }
   function configure_sshd_password_authentication() { echo configure_sshd_password_authentication $*; }
+  function configure_sshd_permit_root_login() { echo configure_sshd_permit_root_login $*; }
   function install_kernel() { echo install_kernel $*; }
   function install_bootloader() { echo install_bootloader $*; }
   function install_epel() { echo install_epel $*; }

--- a/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.kernelless.sh
+++ b/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.kernelless.sh
@@ -36,6 +36,7 @@ function setUp() {
   function configure_hypervisor() { echo configure_hypervisor $*; }
   function configure_selinux() { echo configure_selinux $*; }
   function configure_sshd_password_authentication() { echo configure_sshd_password_authentication $*; }
+  function configure_sshd_permit_root_login() { echo configure_sshd_permit_root_login $*; }
   function configure_sudo_requiretty() { echo configure_sudo_requiretty $*; }
   function install_kernel() { echo install_kernel $*; }
   function install_bootloader() { echo install_bootloader $*; }

--- a/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.sh
+++ b/kvm/rhel/6/test/unit/05_hypervisor/t.install_os.sh
@@ -36,6 +36,7 @@ function setUp() {
   function configure_hypervisor() { echo configure_hypervisor $*; }
   function configure_selinux() { echo configure_selinux $*; }
   function configure_sshd_password_authentication() { echo configure_sshd_password_authentication $*; }
+  function configure_sshd_permit_root_login() { echo configure_sshd_permit_root_login $*; }
   function configure_sudo_requiretty() { echo configure_sudo_requiretty $*; }
   function install_kernel() { echo install_kernel $*; }
   function install_bootloader() { echo install_bootloader $*; }


### PR DESCRIPTION
enable to configure sshd_config PermitRootLogin using sshd_permit_root_login parameter.

selectable values:
- yes (default. sshd_config's default)
- no
- without-password
- forced-commands-only
