### PR TITLE
lock root account if root password is empty

### DIFF
--- a/kvm/rhel/6/functions/distro.sh
+++ b/kvm/rhel/6/functions/distro.sh
@@ -652,7 +652,13 @@ function update_passwords() {
 
   printf "[INFO] Updating passwords\n"
   run_in_target ${chroot_dir} pwconv
-  run_in_target ${chroot_dir} "echo root:${rootpass:-root} | chpasswd"
+
+  # Lock root account only if we didn't set the root password
+  [[ -n "${rootpass}" ]] && {
+    run_in_target ${chroot_dir} "echo root:${rootpass} | chpasswd"
+  } || {
+    run_in_target ${chroot_dir} "usermod -L root"
+  }
 
   [[ -z "${devel_user}" ]] || {
     run_in_target ${chroot_dir} "echo ${devel_user}:${devel_pass:-${devel_user}} | chpasswd"

--- a/kvm/rhel/6/test/unit/04_distro/t.update_passwords.sh
+++ b/kvm/rhel/6/test/unit/04_distro/t.update_passwords.sh
@@ -25,7 +25,7 @@ function tearDown() {
 function test_update_passwords_empty_rootpass() {
   local rootpass=
 
-  update_passwords ${chroot_dir} | egrep -q -w "^chroot ${chroot_dir} bash -e -c echo root:${rootpass} | chpasswd"
+  update_passwords ${chroot_dir} | egrep -q -w "^chroot ${chroot_dir} bash -e -c usermod -L root"
   assertEquals $? 0
 }
 


### PR DESCRIPTION
Previous rootpass default was "root". but this is unsecure.
This change will lock root account if rootpass is empty.

Still you can set root password with "rootpass" parameter.

default rootpass:
- before: root
- after: (empty)

default account setting:
- always unlock
- lock if "rootpass" is empty.
