### PR TITLE
hypervisor/kvm:

### DIFF
--- a/kvm/rhel/6/functions/hypervisor/kvm.sh
+++ b/kvm/rhel/6/functions/hypervisor/kvm.sh
@@ -35,7 +35,9 @@ function add_option_hypervisor_kvm() {
   serial_addr=${serial_addr:-127.0.0.1}
   serial_port=${serial_port:-5555}
 
-  rtc="${rtc:-base=localtime}"
+  # -rtc [base=utc|localtime|date][,clock=host|vm][,driftfix=none|slew]
+  #                 set the RTC base and clock, enable drift fix for clock ticks
+  rtc="${rtc:-base=utc}"
 
   vif_num=${vif_num:-1}
   viftab=${viftab:-}


### PR DESCRIPTION
> rtc

default:
- base=localtime -> base=utc
